### PR TITLE
dns_filter: add external resolution

### DIFF
--- a/source/extensions/filters/udp/dns_filter/BUILD
+++ b/source/extensions/filters/udp/dns_filter/BUILD
@@ -13,16 +13,20 @@ envoy_cc_library(
     name = "dns_filter_lib",
     srcs = [
         "dns_filter.cc",
+        "dns_filter_resolver.cc",
         "dns_parser.cc",
     ],
     hdrs = [
         "dns_filter.h",
+        "dns_filter_resolver.h",
         "dns_parser.h",
     ],
     external_deps = ["ares"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:address_interface",
+        "//include/envoy/network:dns_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/network:listener_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/extensions/filters/udp/dns_filter/dns_filter.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.cc
@@ -116,16 +116,63 @@ bool DnsFilterEnvoyConfig::loadServerConfig(
   return data_source_loaded;
 }
 
+DnsFilter::DnsFilter(Network::UdpReadFilterCallbacks& callbacks,
+                     const DnsFilterEnvoyConfigSharedPtr& config)
+    : UdpListenerReadFilter(callbacks), config_(config), listener_(callbacks.udpListener()),
+      cluster_manager_(config_->clusterManager()),
+      message_parser_(config->forwardQueries(), listener_.dispatcher().timeSource(),
+                      config->retryCount(), config->random(),
+                      config_->stats().downstream_rx_query_latency_) {
+  // This callback is executed when the dns resolution completes. At that time of a response by the
+  // resolver, we build an answer record from each IP returned then send a response to the client
+  resolver_callback_ = [this](DnsQueryContextPtr context, const DnsQueryRecord* query,
+                              AddressConstPtrVec& iplist) -> void {
+    if (context->retry_ &&
+        context->resolver_status_ != Network::DnsResolver::ResolutionStatus::Success) {
+      --context->retry_;
+      ENVOY_LOG(debug, "resolving name [{}] via external resolvers [retry {}]", query->name_,
+                context->retry_);
+      resolver_->resolveExternalQuery(std::move(context), query);
+      return;
+    }
+
+    config_->stats().externally_resolved_queries_.inc();
+
+    incrementExternalQueryTypeCount(query->type_);
+    for (const auto& ip : iplist) {
+      incrementExternalQueryTypeAnswerCount(query->type_);
+      const std::chrono::seconds ttl = getDomainTTL(query->name_);
+      message_parser_.buildDnsAnswerRecord(context, *query, ttl, std::move(ip));
+    }
+    sendDnsResponse(std::move(context));
+  };
+
+  resolver_ = std::make_unique<DnsFilterResolver>(
+      resolver_callback_, config->resolvers(), config->resolverTimeout(), listener_.dispatcher());
+}
+
 void DnsFilter::onData(Network::UdpRecvData& client_request) {
+  config_->stats().downstream_rx_bytes_.recordValue(client_request.buffer_->length());
+  config_->stats().downstream_rx_queries_.inc();
+
+  // Setup counters for the parser
+  DnsParserCounters parser_counters;
+  parser_counters.underflow_counter = &config_->stats().query_buffer_underflow_;
+  parser_counters.record_name_overflow = &config_->stats().record_name_overflow_;
+  parser_counters.query_parsing_failure = &config_->stats().query_parsing_failure_;
+
   // Parse the query, if it fails return an response to the client
-  DnsQueryContextPtr query_context = message_parser_.createQueryContext(client_request);
+  DnsQueryContextPtr query_context =
+      message_parser_.createQueryContext(client_request, parser_counters);
+  incrementQueryTypeCount(query_context->queries_);
   if (!query_context->parse_status_) {
+    config_->stats().downstream_rx_invalid_queries_.inc();
     sendDnsResponse(std::move(query_context));
     return;
   }
 
   // Resolve the requested name
-  const auto response = getResponseForQuery(query_context);
+  auto response = getResponseForQuery(query_context);
 
   // We were not able to satisfy the request locally. Return an empty response to the client
   if (response == DnsLookupResponseCode::Failure) {
@@ -133,7 +180,11 @@ void DnsFilter::onData(Network::UdpRecvData& client_request) {
     return;
   }
 
-  // TODO(abaptiste): external resolution
+  // Externally resolved. We'll respond to the client when the external DNS resolution callback
+  // is executed
+  if (response == DnsLookupResponseCode::External) {
+    return;
+  }
 
   // We have an answer. Send it to the client
   sendDnsResponse(std::move(query_context));
@@ -145,6 +196,8 @@ void DnsFilter::sendDnsResponse(DnsQueryContextPtr query_context) {
   // Serializes the generated response to the parsed query from the client. If there is a
   // parsing error or the incoming query is invalid, we will still generate a valid DNS response
   message_parser_.buildResponseBuffer(query_context, response);
+  config_->stats().downstream_tx_responses_.inc();
+  config_->stats().downstream_tx_bytes_.recordValue(response.length());
   Network::UdpSendData response_data{query_context->local_->ip(), *(query_context->peer_),
                                      response};
   listener_.send(response_data);
@@ -174,10 +227,15 @@ DnsLookupResponseCode DnsFilter::getResponseForQuery(DnsQueryContextPtr& context
         continue;
       }
     }
-    // TODO(abaptiste): resolve the query externally
+
+    ENVOY_LOG(debug, "resolving name [{}] via external resolvers", query->name_);
+    resolver_->resolveExternalQuery(std::move(context), query.get());
+
+    return DnsLookupResponseCode::External;
   }
 
   if (context->answers_.empty()) {
+    config_->stats().unanswered_queries_.inc();
     return DnsLookupResponseCode::Failure;
   }
   return DnsLookupResponseCode::Success;
@@ -206,6 +264,7 @@ bool DnsFilter::isKnownDomain(const absl::string_view domain_name) {
   // TODO(abaptiste): Use a trie to find a match instead of iterating through the list
   for (auto& suffix : known_suffixes) {
     if (suffix->match(domain_name)) {
+      config_->stats().known_domain_queries_.inc();
       return true;
     }
   }
@@ -264,6 +323,7 @@ bool DnsFilter::resolveViaClusters(DnsQueryContextPtr& context, const DnsQueryRe
       ++discovered_endpoints;
       ENVOY_LOG(debug, "using cluster host address {} for domain [{}]",
                 host->address()->ip()->addressAsString(), lookup_name);
+      incrementClusterQueryTypeAnswerCount(query.type_);
       message_parser_.buildDnsAnswerRecord(context, query, ttl, host->address());
     }
   }
@@ -287,6 +347,7 @@ bool DnsFilter::resolveViaConfiguredHosts(DnsQueryContextPtr& context,
   uint64_t hosts_found = 0;
   for (const auto& configured_address : *configured_address_list) {
     ASSERT(configured_address != nullptr);
+    incrementLocalQueryTypeAnswerCount(query.type_);
     ENVOY_LOG(debug, "using local address {} for domain [{}]",
               configured_address->ip()->addressAsString(), query.name_);
     ++hosts_found;
@@ -297,6 +358,7 @@ bool DnsFilter::resolveViaConfiguredHosts(DnsQueryContextPtr& context,
 }
 
 void DnsFilter::onReceiveError(Api::IoError::IoErrorCode error_code) {
+  config_->stats().downstream_rx_errors_.inc();
   UNREFERENCED_PARAMETER(error_code);
 }
 

--- a/source/extensions/filters/udp/dns_filter/dns_filter.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.h
@@ -2,6 +2,7 @@
 
 #include "envoy/event/file_event.h"
 #include "envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.pb.h"
+#include "envoy/network/dns.h"
 #include "envoy/network/filter.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -9,6 +10,7 @@
 #include "common/config/config_provider_impl.h"
 #include "common/network/utility.h"
 
+#include "extensions/filters/udp/dns_filter/dns_filter_resolver.h"
 #include "extensions/filters/udp/dns_filter/dns_parser.h"
 
 #include "absl/container/flat_hash_set.h"
@@ -20,21 +22,42 @@ namespace DnsFilter {
 
 /**
  * All DNS Filter stats. @see stats_macros.h
- * Track the number of answered and un-answered queries for A and AAAA records
  */
-#define ALL_DNS_FILTER_STATS(COUNTER)                                                              \
-  COUNTER(queries_a_record)                                                                        \
-  COUNTER(noanswers_a_record)                                                                      \
-  COUNTER(answers_a_record)                                                                        \
-  COUNTER(queries_aaaa_record)                                                                     \
-  COUNTER(noanswers_aaaa_record)                                                                   \
-  COUNTER(answers_aaaa_record)
+#define ALL_DNS_FILTER_STATS(COUNTER, HISTOGRAM)                                                   \
+  COUNTER(a_record_queries)                                                                        \
+  COUNTER(aaaa_record_queries)                                                                     \
+  COUNTER(cluster_a_record_answers)                                                                \
+  COUNTER(cluster_aaaa_record_answers)                                                             \
+  COUNTER(cluster_unsupported_answers)                                                             \
+  COUNTER(downstream_rx_errors)                                                                    \
+  COUNTER(downstream_rx_invalid_queries)                                                           \
+  COUNTER(downstream_rx_queries)                                                                   \
+  COUNTER(external_a_record_queries)                                                               \
+  COUNTER(external_a_record_answers)                                                               \
+  COUNTER(external_aaaa_record_answers)                                                            \
+  COUNTER(external_aaaa_record_queries)                                                            \
+  COUNTER(external_unsupported_answers)                                                            \
+  COUNTER(external_unsupported_queries)                                                            \
+  COUNTER(externally_resolved_queries)                                                             \
+  COUNTER(known_domain_queries)                                                                    \
+  COUNTER(local_a_record_answers)                                                                  \
+  COUNTER(local_aaaa_record_answers)                                                               \
+  COUNTER(local_unsupported_answers)                                                               \
+  COUNTER(unanswered_queries)                                                                      \
+  COUNTER(unsupported_queries)                                                                     \
+  COUNTER(downstream_tx_responses)                                                                 \
+  COUNTER(query_buffer_underflow)                                                                  \
+  COUNTER(query_parsing_failure)                                                                   \
+  COUNTER(record_name_overflow)                                                                    \
+  HISTOGRAM(downstream_rx_bytes, Bytes)                                                            \
+  HISTOGRAM(downstream_rx_query_latency, Milliseconds)                                             \
+  HISTOGRAM(downstream_tx_bytes, Bytes)
 
 /**
  * Struct definition for all DNS Filter stats. @see stats_macros.h
  */
 struct DnsFilterStats {
-  ALL_DNS_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+  ALL_DNS_FILTER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 struct DnsEndpointConfig {
@@ -69,7 +92,8 @@ public:
 private:
   static DnsFilterStats generateStats(const std::string& stat_prefix, Stats::Scope& scope) {
     const auto final_prefix = absl::StrCat("dns_filter.", stat_prefix);
-    return {ALL_DNS_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
+    return {ALL_DNS_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix),
+                                 POOL_HISTOGRAM_PREFIX(scope, final_prefix))};
   }
 
   bool loadServerConfig(const envoy::extensions::filters::udp::dns_filter::v3alpha::
@@ -78,6 +102,7 @@ private:
 
   Stats::Scope& root_scope_;
   Upstream::ClusterManager& cluster_manager_;
+  Network::DnsResolverSharedPtr resolver_;
   Api::Api& api_;
 
   mutable DnsFilterStats stats_;
@@ -102,14 +127,12 @@ enum class DnsLookupResponseCode { Success, Failure, External };
  */
 class DnsFilter : public Network::UdpListenerReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  DnsFilter(Network::UdpReadFilterCallbacks& callbacks, const DnsFilterEnvoyConfigSharedPtr& config)
-      : UdpListenerReadFilter(callbacks), config_(config), listener_(callbacks.udpListener()),
-        cluster_manager_(config_->clusterManager()),
-        message_parser_(config->forwardQueries(), config->retryCount(), config->random()) {}
+  DnsFilter(Network::UdpReadFilterCallbacks& callbacks,
+            const DnsFilterEnvoyConfigSharedPtr& config);
 
   // Network::UdpListenerReadFilter callbacks
   void onData(Network::UdpRecvData& client_request) override;
-  void onReceiveError(Api::IoError::IoErrorCode error_code) override;
+  void onReceiveError(Api::IoError::IoErrorCode) override;
 
   /**
    * @return bool true if the domain_name is a known domain for which we respond to queries
@@ -133,7 +156,8 @@ private:
   DnsLookupResponseCode getResponseForQuery(DnsQueryContextPtr& context);
 
   /**
-   * @return uint32_t retrieves the configured per domain TTL to be inserted into answer records
+   * @return std::chrono::seconds retrieves the configured per domain TTL to be inserted into answer
+   * records
    */
   std::chrono::seconds getDomainTTL(const absl::string_view domain);
 
@@ -157,6 +181,114 @@ private:
   bool resolveViaConfiguredHosts(DnsQueryContextPtr& context, const DnsQueryRecord& query);
 
   /**
+   * @brief Increment the counter for the given query type for external queries
+   *
+   * @param query_type indicate the type of record being resolved (A, AAAA, or other).
+   */
+  void incrementExternalQueryTypeCount(const uint16_t query_type) {
+    switch (query_type) {
+    case DNS_RECORD_TYPE_A:
+      config_->stats().external_a_record_queries_.inc();
+      break;
+    case DNS_RECORD_TYPE_AAAA:
+      config_->stats().external_aaaa_record_queries_.inc();
+      break;
+    default:
+      config_->stats().external_unsupported_queries_.inc();
+      break;
+    }
+  }
+
+  /**
+   * @brief Increment the counter for the parsed query type
+   *
+   * @param queries a vector of all the incoming queries received from a client
+   */
+  void incrementQueryTypeCount(const DnsQueryPtrVec& queries) {
+    for (const auto& query : queries) {
+      incrementQueryTypeCount(query->type_);
+    }
+  }
+
+  /**
+   * @brief Increment the counter for the given query type.
+   *
+   * @param query_type indicate the type of record being resolved (A, AAAA, or other).
+   */
+  void incrementQueryTypeCount(const uint16_t query_type) {
+    switch (query_type) {
+    case DNS_RECORD_TYPE_A:
+      config_->stats().a_record_queries_.inc();
+      break;
+    case DNS_RECORD_TYPE_AAAA:
+      config_->stats().aaaa_record_queries_.inc();
+      break;
+    default:
+      config_->stats().unsupported_queries_.inc();
+      break;
+    }
+  }
+
+  /**
+   * @brief Increment the counter for answers for the given query type resolved via cluster names
+   *
+   * @param query_type indicate the type of answer record returned to the client
+   */
+  void incrementClusterQueryTypeAnswerCount(const uint16_t query_type) {
+    switch (query_type) {
+    case DNS_RECORD_TYPE_A:
+      config_->stats().cluster_a_record_answers_.inc();
+      break;
+    case DNS_RECORD_TYPE_AAAA:
+      config_->stats().cluster_aaaa_record_answers_.inc();
+      break;
+    default:
+      config_->stats().cluster_unsupported_answers_.inc();
+      break;
+    }
+  }
+
+  /**
+   * @brief Increment the counter for answers for the given query type resolved from the local
+   * configuration.
+   *
+   * @param query_type indicate the type of answer record returned to the client
+   */
+  void incrementLocalQueryTypeAnswerCount(const uint16_t query_type) {
+    switch (query_type) {
+    case DNS_RECORD_TYPE_A:
+      config_->stats().local_a_record_answers_.inc();
+      break;
+    case DNS_RECORD_TYPE_AAAA:
+      config_->stats().local_aaaa_record_answers_.inc();
+      break;
+    default:
+      config_->stats().local_unsupported_answers_.inc();
+      break;
+    }
+  }
+
+  /**
+   * @brief Increment the counter for answers for the given query type resolved via an external
+   * resolver
+   *
+   * @param query_type indicate the type of answer record returned to the client
+   */
+  void incrementExternalQueryTypeAnswerCount(const uint16_t query_type) {
+    switch (query_type) {
+    case DNS_RECORD_TYPE_A:
+      config_->stats().external_a_record_answers_.inc();
+      break;
+    case DNS_RECORD_TYPE_AAAA:
+      config_->stats().external_aaaa_record_answers_.inc();
+      break;
+    default:
+      config_->stats().external_unsupported_answers_.inc();
+      break;
+    }
+  }
+
+  /**
    * @brief Helper function to retrieve the Endpoint configuration for a requested domain
    */
   const DnsEndpointConfig* getEndpointConfigForDomain(const absl::string_view domain);
@@ -175,9 +307,10 @@ private:
   Network::UdpListener& listener_;
   Upstream::ClusterManager& cluster_manager_;
   DnsMessageParser message_parser_;
+  DnsFilterResolverPtr resolver_;
   Network::Address::InstanceConstSharedPtr local_;
   Network::Address::InstanceConstSharedPtr peer_;
-  AnswerCallback answer_callback_;
+  DnsFilterResolverCallback resolver_callback_;
 };
 
 } // namespace DnsFilter

--- a/source/extensions/filters/udp/dns_filter/dns_filter.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.h
@@ -132,7 +132,7 @@ public:
 
   // Network::UdpListenerReadFilter callbacks
   void onData(Network::UdpRecvData& client_request) override;
-  void onReceiveError(Api::IoError::IoErrorCode) override;
+  void onReceiveError(Api::IoError::IoErrorCode error_code) override;
 
   /**
    * @return bool true if the domain_name is a known domain for which we respond to queries

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
@@ -1,0 +1,76 @@
+#include "extensions/filters/udp/dns_filter/dns_filter_resolver.h"
+
+#include "common/network/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace UdpFilters {
+namespace DnsFilter {
+
+void DnsFilterResolver::resolveExternalQuery(DnsQueryContextPtr context,
+                                             const DnsQueryRecord* domain_query) {
+  if (active_query_ != nullptr) {
+    active_query_->cancel();
+    active_query_ = nullptr;
+  }
+  external_context_ = std::move(context);
+
+  // Because the context can have more than one query, we need to maintain a pointer to the current
+  // query that is being resolved. Since domain_query is a unique pointer to a record in the
+  // context, we use a standard pointer to reference the query data when building the response
+  query_rec_ = domain_query;
+
+  resolution_status_ = DnsFilterResolverStatus::Pending;
+  timeout_timer_->disableTimer();
+
+  Network::DnsLookupFamily lookup_family;
+  switch (domain_query->type_) {
+  case DNS_RECORD_TYPE_A:
+    lookup_family = Network::DnsLookupFamily::V4Only;
+    break;
+  case DNS_RECORD_TYPE_AAAA:
+    lookup_family = Network::DnsLookupFamily::V6Only;
+    break;
+  default:
+    ENVOY_LOG(debug, "Unknown query type [{}] for upstream lookup", domain_query->type_);
+    invokeCallback(Network::DnsResolver::ResolutionStatus::Failure);
+    return;
+  }
+
+  // Re-arm the timeout timer
+  timeout_timer_->enableTimer(timeout_);
+
+  // Define the callback that is executed when resolution completes
+  auto resolve_cb = [this](Network::DnsResolver::ResolutionStatus status,
+                           std::list<Network::DnsResponse>&& response) -> void {
+    active_query_ = nullptr;
+    ENVOY_LOG(trace, "async query status returned. Entries {}", response.size());
+    if (resolution_status_ != DnsFilterResolverStatus::Pending) {
+      ENVOY_LOG(debug, "Resolution timed out before callback was executed");
+      return;
+    }
+    resolution_status_ = DnsFilterResolverStatus::Complete;
+    // We are processing the response here, so we did not timeout. Cancel the timer
+    timeout_timer_->disableTimer();
+
+    // C-ares doesn't expose the TTL in the data available here.
+    if (status == Network::DnsResolver::ResolutionStatus::Success) {
+      for (const auto& resp : response) {
+        ASSERT(resp.address_ != nullptr);
+        ENVOY_LOG(trace, "Resolved address: {} for {}", resp.address_->ip()->addressAsString(),
+                  query_rec_->name_);
+        resolved_hosts_.push_back(std::move(resp.address_));
+      }
+    }
+    // Invoke the filter callback notifying it of resolved addresses
+    invokeCallback(status);
+  };
+
+  // Resolve the address in the query and add to the resolved_hosts vector
+  resolved_hosts_.clear();
+  active_query_ = resolver_->resolve(domain_query->name_, lookup_family, resolve_cb);
+}
+} // namespace DnsFilter
+} // namespace UdpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/network/dns.h"
+
+#include "extensions/filters/udp/dns_filter/dns_parser.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace UdpFilters {
+namespace DnsFilter {
+
+enum class DnsFilterResolverStatus { Pending, Complete, TimedOut };
+
+/*
+ * This class encapsulates the logic of handling an asynchronous DNS request for the DNS filter.
+ * External request timeouts are handled here.
+ */
+class DnsFilterResolver : Logger::Loggable<Logger::Id::filter> {
+public:
+  DnsFilterResolver(DnsFilterResolverCallback& callback, AddressConstPtrVec resolvers,
+                    std::chrono::milliseconds timeout, Event::Dispatcher& dispatcher)
+      : resolver_(dispatcher.createDnsResolver(resolvers, false /* use_tcp_for_dns_lookups */)),
+        callback_(callback), timeout_(timeout),
+        timeout_timer_(dispatcher.createTimer([this]() -> void { onResolveTimeout(); })),
+        active_query_(nullptr) {}
+
+  /**
+   * @brief entry point to resolve the name in a DnsQueryRecord
+   *
+   * This function uses the query object to determine whether it is requesting an A or AAAA record
+   * for the given name. When the resolver callback executes, this will execute a DNS Filter
+   * callback in order to build the answer object returned to the client.
+   *
+   * @param domain_query the query record object containing the name for which we are resolving
+   */
+  void resolveExternalQuery(DnsQueryContextPtr context, const DnsQueryRecord* domain_query);
+
+private:
+  /**
+   * @brief invokes the DNS Filter callback only if our state indicates we have not timed out
+   * waiting for a response from the external resolver
+   */
+  void invokeCallback(Network::DnsResolver::ResolutionStatus status) {
+    // We've timed out. Guard against sending a response
+    if (resolution_status_ == DnsFilterResolverStatus::TimedOut) {
+      return;
+    }
+
+    timeout_timer_->disableTimer();
+    external_context_->resolver_status_ = status;
+    callback_(std::move(external_context_), query_rec_, resolved_hosts_);
+  }
+
+  /**
+   * @brief Invoke the DNS Filter callback after explicitly clearing the resolved hosts list. The
+   * DNS Filter will respond to the client appropriately.
+   */
+  void onResolveTimeout() {
+    // Guard against executing the filter callback and sending a response
+    if (resolution_status_ != DnsFilterResolverStatus::Pending) {
+      return;
+    }
+    resolution_status_ = DnsFilterResolverStatus::TimedOut;
+    resolved_hosts_.clear();
+    external_context_->resolver_status_ = Network::DnsResolver::ResolutionStatus::Failure;
+    callback_(std::move(external_context_), query_rec_, resolved_hosts_);
+  }
+
+  const Network::DnsResolverSharedPtr resolver_;
+  DnsFilterResolverCallback& callback_;
+  std::chrono::milliseconds timeout_;
+  Event::TimerPtr timeout_timer_;
+  const DnsQueryRecord* query_rec_;
+  Network::ActiveDnsQuery* active_query_;
+  DnsFilterResolverStatus resolution_status_;
+  AddressConstPtrVec resolved_hosts_;
+  DnsQueryContextPtr external_context_;
+};
+
+using DnsFilterResolverPtr = std::unique_ptr<DnsFilterResolver>;
+
+} // namespace DnsFilter
+} // namespace UdpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/udp/dns_filter/dns_parser.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_parser.cc
@@ -102,9 +102,10 @@ bool DnsAnswerRecord::serialize(Buffer::OwnedImpl& output) {
   return false;
 }
 
-DnsQueryContextPtr DnsMessageParser::createQueryContext(Network::UdpRecvData& client_request) {
+DnsQueryContextPtr DnsMessageParser::createQueryContext(Network::UdpRecvData& client_request,
+                                                        DnsParserCounters& counters) {
   DnsQueryContextPtr query_context = std::make_unique<DnsQueryContext>(
-      client_request.addresses_.local_, client_request.addresses_.peer_);
+      client_request.addresses_.local_, client_request.addresses_.peer_, counters, retry_count_);
 
   query_context->parse_status_ = parseDnsObject(query_context, client_request.buffer_);
   if (!query_context->parse_status_) {
@@ -127,6 +128,9 @@ bool DnsMessageParser::parseDnsObject(DnsQueryContextPtr& context,
   while (state != DnsQueryParseState::Finish) {
     // Ensure that we have enough data remaining in the buffer to parse the query
     if (available_bytes < field_size) {
+      if (context->counters_.underflow_counter) {
+        context->counters_.underflow_counter->inc();
+      }
       ENVOY_LOG(debug,
                 "Exhausted available bytes in the buffer. Insufficient data to parse query field.");
       return false;
@@ -204,6 +208,9 @@ bool DnsMessageParser::parseDnsObject(DnsQueryContextPtr& context,
     ENVOY_LOG(trace, "Parsing [{}/{}] questions", index, header_.questions);
     auto rec = parseDnsQueryRecord(buffer, &offset);
     if (rec == nullptr) {
+      if (context->counters_.query_parsing_failure) {
+        context->counters_.query_parsing_failure->inc();
+      }
       ENVOY_LOG(debug, "Couldn't parse query record from buffer");
       return false;
     }
@@ -360,7 +367,7 @@ DnsAnswerRecordPtr DnsMessageParser::parseDnsAnswerRecord(const Buffer::Instance
   *offset = data_offset;
 
   return std::make_unique<DnsAnswerRecord>(record_name, record_type, record_class,
-                                           std::chrono::seconds{ttl}, std::move(ip_addr));
+                                           std::chrono::seconds(ttl), std::move(ip_addr));
 }
 
 DnsQueryRecordPtr DnsMessageParser::parseDnsQueryRecord(const Buffer::InstancePtr& buffer,
@@ -402,7 +409,11 @@ DnsQueryRecordPtr DnsMessageParser::parseDnsQueryRecord(const Buffer::InstancePt
     return nullptr;
   }
 
-  // stop reading he buffer here since we aren't parsing additional records
+  auto rec = std::make_unique<DnsQueryRecord>(record_name, record_type, record_class);
+  rec->query_time_ms_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      query_latency_histogram_, timesource_);
+
+  // stop reading the buffer here since we aren't parsing additional records
   ENVOY_LOG(trace, "Extracted query record. Name: {} type: {} class: {}", record_name, record_type,
             record_class);
 

--- a/source/extensions/filters/udp/dns_filter/dns_parser.h
+++ b/source/extensions/filters/udp/dns_filter/dns_parser.h
@@ -3,10 +3,12 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/platform.h"
 #include "envoy/network/address.h"
+#include "envoy/network/dns.h"
 #include "envoy/network/listener.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/runtime/runtime_impl.h"
+#include "common/stats/timespan_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -48,12 +50,13 @@ public:
   DnsQueryRecord(const std::string& rec_name, const uint16_t rec_type, const uint16_t rec_class)
       : BaseDnsRecord(rec_name, rec_type, rec_class) {}
   bool serialize(Buffer::OwnedImpl& output) override;
+
+  std::unique_ptr<Stats::HistogramCompletableTimespanImpl> query_time_ms_;
 };
 
 using DnsQueryRecordPtr = std::unique_ptr<DnsQueryRecord>;
 using DnsQueryPtrVec = std::vector<DnsQueryRecordPtr>;
 using AddressConstPtrVec = std::vector<Network::Address::InstanceConstSharedPtr>;
-using AnswerCallback = std::function<void(DnsQueryRecordPtr& query, AddressConstPtrVec& ipaddr)>;
 
 /**
  * DnsAnswerRecord represents a single answer record for a name that is to be serialized and sent to
@@ -75,25 +78,41 @@ using DnsAnswerRecordPtr = std::unique_ptr<DnsAnswerRecord>;
 using DnsAnswerMap = std::unordered_multimap<std::string, DnsAnswerRecordPtr>;
 
 /**
+ * @brief This struct is used to hold pointers to the counters that are relevant to the
+ * parser. This is done to prevent dependency loops between the parser and filter headers
+ */
+struct DnsParserCounters {
+  Stats::Counter* underflow_counter;
+  Stats::Counter* record_name_overflow;
+  Stats::Counter* query_parsing_failure;
+};
+
+/**
  * DnsQueryContext contains all the data necessary for responding to a query from a given client.
  */
 class DnsQueryContext {
 public:
   DnsQueryContext(Network::Address::InstanceConstSharedPtr local,
-                  Network::Address::InstanceConstSharedPtr peer)
-      : local_(std::move(local)), peer_(std::move(peer)), parse_status_(false),
-        response_code_(DNS_RESPONSE_CODE_NO_ERROR) {}
+                  Network::Address::InstanceConstSharedPtr peer, DnsParserCounters& counters,
+                  uint64_t retry_count)
+      : local_(std::move(local)), peer_(std::move(peer)), counters_(counters), parse_status_(false),
+        response_code_(DNS_RESPONSE_CODE_NO_ERROR), retry_(retry_count) {}
 
   const Network::Address::InstanceConstSharedPtr local_;
   const Network::Address::InstanceConstSharedPtr peer_;
+  DnsParserCounters& counters_;
   bool parse_status_;
   uint16_t response_code_;
+  uint64_t retry_;
   uint16_t id_;
+  Network::DnsResolver::ResolutionStatus resolver_status_;
   DnsQueryPtrVec queries_;
   DnsAnswerMap answers_;
 };
 
 using DnsQueryContextPtr = std::unique_ptr<DnsQueryContext>;
+using DnsFilterResolverCallback = std::function<void(
+    DnsQueryContextPtr context, const DnsQueryRecord* current_query, AddressConstPtrVec& ipaddr)>;
 
 /**
  * This class orchestrates parsing a DNS query and building the response to be sent to a client.
@@ -139,8 +158,10 @@ public:
     uint16_t additional_rrs;
   });
 
-  DnsMessageParser(bool recurse, uint64_t retry_count, Runtime::RandomGenerator& random)
-      : recursion_available_(recurse), retry_count_(retry_count), rng_(random) {}
+  DnsMessageParser(bool recurse, TimeSource& timesource, uint64_t retry_count,
+                   Runtime::RandomGenerator& random, Stats::Histogram& latency_histogram)
+      : recursion_available_(recurse), timesource_(timesource), retry_count_(retry_count),
+        query_latency_histogram_(latency_histogram), rng_(random) {}
 
   /**
    * @brief Builds an Answer record for the active query. The active query transaction ID is at the
@@ -209,7 +230,8 @@ public:
    * @param client_request a structure containing addressing information and the buffer received
    * from a client
    */
-  DnsQueryContextPtr createQueryContext(Network::UdpRecvData& client_request);
+  DnsQueryContextPtr createQueryContext(Network::UdpRecvData& client_request,
+                                        DnsParserCounters& counters);
   /**
    * @param buffer a reference to the incoming request object received by the listener
    * @return bool true if all DNS records and flags were successfully parsed from the buffer
@@ -249,7 +271,9 @@ private:
                                        uint64_t* name_offset);
 
   bool recursion_available_;
+  TimeSource& timesource_;
   uint64_t retry_count_;
+  Stats::Histogram& query_latency_histogram_;
   DnsHeader header_;
   DnsHeader response_header_;
   Runtime::RandomGenerator& rng_;

--- a/test/extensions/filters/udp/dns_filter/dns_filter_fuzz_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_fuzz_test.cc
@@ -17,46 +17,48 @@ namespace UdpFilters {
 namespace DnsFilter {
 namespace {
 
-const std::string generateQuery(FuzzedDataProvider* data_provider) {
-  size_t query_size = data_provider->ConsumeIntegralInRange<size_t>(0, 512);
-  return data_provider->ConsumeRandomLengthString(query_size);
-}
-
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
-  FuzzedDataProvider data_provider(buf, len);
-  const bool recurse = data_provider.ConsumeBool();
-  const uint16_t retry_count = data_provider.ConsumeIntegralInRange<uint16_t>(0, 3);
+  static const auto local = Network::Utility::parseInternetAddressAndPort("127.0.2.1:5353");
+  static const auto peer = Network::Utility::parseInternetAddressAndPort("127.0.2.1:55088");
 
   static NiceMock<Runtime::MockRandomGenerator> random;
-  DnsMessageParser message_parser(recurse, retry_count, random);
+  static NiceMock<Stats::MockHistogram> histogram;
+  histogram.unit_ = Stats::Histogram::Unit::Milliseconds;
+  static Api::ApiPtr api = Api::createApiForTest();
 
-  const auto local = Network::Utility::parseInternetAddressAndPort("127.0.2.1:5353");
-  const auto peer = Network::Utility::parseInternetAddressAndPort("127.0.2.1:55088");
-
+  FuzzedDataProvider data_provider(buf, len);
   Buffer::InstancePtr query_buffer = std::make_unique<Buffer::OwnedImpl>();
-  const std::string query = generateQuery(&data_provider);
-  query_buffer->add(query.data(), query.size());
 
-  const uint8_t fuzz_function = data_provider.ConsumeIntegralInRange<uint8_t>(0, 2);
-  switch (fuzz_function) {
-  case 0: {
-    DnsQueryContextPtr query_context = std::make_unique<DnsQueryContext>(local, peer);
-    bool result = message_parser.parseDnsObject(query_context, query_buffer);
-    UNREFERENCED_PARAMETER(result);
-  } break;
+  while (data_provider.remaining_bytes()) {
+    const std::string query = data_provider.ConsumeRandomLengthString(1024);
+    query_buffer->add(query.data(), query.size());
 
-  case 1: {
-    uint64_t offset = data_provider.ConsumeIntegralInRange<uint64_t>(0, query_buffer->length());
-    DnsQueryRecordPtr ptr = message_parser.parseDnsQueryRecord(query_buffer, &offset);
-    UNREFERENCED_PARAMETER(ptr);
-  } break;
+    const uint16_t retry_count = data_provider.ConsumeIntegralInRange<uint16_t>(0, 3);
+    DnsMessageParser message_parser(true, api->timeSource(), retry_count, random, histogram);
+    uint64_t offset = data_provider.ConsumeIntegralInRange<uint64_t>(0, query.size());
 
-  case 2: {
-    uint64_t offset = data_provider.ConsumeIntegralInRange<uint64_t>(0, query_buffer->length());
-    DnsAnswerRecordPtr ptr = message_parser.parseDnsAnswerRecord(query_buffer, &offset);
-    UNREFERENCED_PARAMETER(ptr);
-  } break;
-  } // end case
+    const uint8_t fuzz_function = data_provider.ConsumeIntegralInRange<uint8_t>(0, 2);
+    switch (fuzz_function) {
+    case 0: {
+      DnsParserCounters counters{};
+      DnsQueryContextPtr query_context =
+          std::make_unique<DnsQueryContext>(local, peer, counters, retry_count);
+      bool result = message_parser.parseDnsObject(query_context, query_buffer);
+      UNREFERENCED_PARAMETER(result);
+    } break;
+
+    case 1: {
+      DnsQueryRecordPtr ptr = message_parser.parseDnsQueryRecord(query_buffer, &offset);
+      UNREFERENCED_PARAMETER(ptr);
+    } break;
+
+    case 2: {
+      DnsAnswerRecordPtr ptr = message_parser.parseDnsAnswerRecord(query_buffer, &offset);
+      UNREFERENCED_PARAMETER(ptr);
+    } break;
+    } // end case
+    query_buffer->drain(query_buffer->length());
+  }
 }
 } // namespace
 } // namespace DnsFilter

--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -16,13 +16,15 @@ namespace {
 class DnsFilterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                  public BaseIntegrationTest {
 public:
-  DnsFilterIntegrationTest() : BaseIntegrationTest(GetParam(), configToUse()) {
+  DnsFilterIntegrationTest()
+      : BaseIntegrationTest(GetParam(), configToUse()), api_(Api::createApiForTest()) {
     setupResponseParser();
   }
 
   void setupResponseParser() {
-    response_parser_ = std::make_unique<DnsMessageParser>(true /*recursive queries */,
-                                                          0 /* retry_count */, random_);
+    histogram_.unit_ = Stats::Histogram::Unit::Milliseconds;
+    response_parser_ = std::make_unique<DnsMessageParser>(
+        true /* recursive queries */, api_->timeSource(), 3 /* retries */, random_, histogram_);
   }
 
   static std::string configToUse() {
@@ -32,6 +34,10 @@ public:
       typed_config:
         '@type': 'type.googleapis.com/envoy.extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig'
         stat_prefix: "my_prefix"
+        client_config:
+          resolver_timeout: 5s
+          upstream_resolvers:
+          - "8.8.8.8"
         server_config:
           inline_dns_table:
             external_retry_count: 3
@@ -88,7 +94,10 @@ public:
     client.recv(response_datagram);
   }
 
+  Api::ApiPtr api_;
+  NiceMock<Stats::MockHistogram> histogram_;
   NiceMock<Runtime::MockRandomGenerator> random_;
+  DnsParserCounters counters_;
   std::unique_ptr<DnsMessageParser> response_parser_;
   DnsQueryContextPtr query_ctx_;
 };
@@ -96,6 +105,42 @@ public:
 INSTANTIATE_TEST_SUITE_P(IpVersions, DnsFilterIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
+
+TEST_P(DnsFilterIntegrationTest, ExternalLookupTest) {
+  setup(0);
+  const uint32_t port = lookupPort("listener_0");
+  const auto listener_address = Network::Utility::resolveUrl(
+      fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
+
+  Network::UdpRecvData response;
+  std::string query =
+      Utils::buildQueryForDomain("www.google.com", DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN);
+  requestResponseWithListenerAddress(*listener_address, query, response);
+
+  query_ctx_ = response_parser_->createQueryContext(response, counters_);
+  ASSERT_TRUE(query_ctx_->parse_status_);
+
+  ASSERT_EQ(1, query_ctx_->answers_.size());
+  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+}
+
+TEST_P(DnsFilterIntegrationTest, ExternalLookupTestIPv6) {
+  setup(0);
+  const uint32_t port = lookupPort("listener_0");
+  const auto listener_address = Network::Utility::resolveUrl(
+      fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
+
+  Network::UdpRecvData response;
+  std::string query =
+      Utils::buildQueryForDomain("www.google.com", DNS_RECORD_TYPE_AAAA, DNS_RECORD_CLASS_IN);
+  requestResponseWithListenerAddress(*listener_address, query, response);
+
+  query_ctx_ = response_parser_->createQueryContext(response, counters_);
+  ASSERT_TRUE(query_ctx_->parse_status_);
+
+  ASSERT_EQ(1, query_ctx_->answers_.size());
+  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+}
 
 TEST_P(DnsFilterIntegrationTest, LocalLookupTest) {
   setup(0);
@@ -108,11 +153,11 @@ TEST_P(DnsFilterIntegrationTest, LocalLookupTest) {
       Utils::buildQueryForDomain("www.foo1.com", DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN);
   requestResponseWithListenerAddress(*listener_address, query, response);
 
-  query_ctx_ = response_parser_->createQueryContext(response);
-  EXPECT_TRUE(query_ctx_->parse_status_);
+  query_ctx_ = response_parser_->createQueryContext(response, counters_);
+  ASSERT_TRUE(query_ctx_->parse_status_);
 
-  EXPECT_EQ(4, query_ctx_->answers_.size());
-  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  ASSERT_EQ(4, query_ctx_->answers_.size());
+  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, ClusterLookupTest) {
@@ -132,11 +177,11 @@ TEST_P(DnsFilterIntegrationTest, ClusterLookupTest) {
   std::string query = Utils::buildQueryForDomain("cluster_0", record_type, DNS_RECORD_CLASS_IN);
   requestResponseWithListenerAddress(*listener_address, query, response);
 
-  query_ctx_ = response_parser_->createQueryContext(response);
-  EXPECT_TRUE(query_ctx_->parse_status_);
+  query_ctx_ = response_parser_->createQueryContext(response, counters_);
+  ASSERT_TRUE(query_ctx_->parse_status_);
 
-  EXPECT_EQ(2, query_ctx_->answers_.size());
-  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  ASSERT_EQ(2, query_ctx_->answers_.size());
+  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, ClusterEndpointLookupTest) {
@@ -157,11 +202,11 @@ TEST_P(DnsFilterIntegrationTest, ClusterEndpointLookupTest) {
       Utils::buildQueryForDomain("cluster.foo1.com", record_type, DNS_RECORD_CLASS_IN);
   requestResponseWithListenerAddress(*listener_address, query, response);
 
-  query_ctx_ = response_parser_->createQueryContext(response);
-  EXPECT_TRUE(query_ctx_->parse_status_);
+  query_ctx_ = response_parser_->createQueryContext(response, counters_);
+  ASSERT_TRUE(query_ctx_->parse_status_);
 
-  EXPECT_EQ(2, query_ctx_->answers_.size());
-  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  ASSERT_EQ(2, query_ctx_->answers_.size());
+  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 } // namespace

--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -118,10 +118,10 @@ TEST_P(DnsFilterIntegrationTest, ExternalLookupTest) {
   requestResponseWithListenerAddress(*listener_address, query, response);
 
   query_ctx_ = response_parser_->createQueryContext(response, counters_);
-  ASSERT_TRUE(query_ctx_->parse_status_);
+  EXPECT_TRUE(query_ctx_->parse_status_);
 
-  ASSERT_EQ(1, query_ctx_->answers_.size());
-  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  EXPECT_EQ(1, query_ctx_->answers_.size());
+  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, ExternalLookupTestIPv6) {
@@ -136,10 +136,10 @@ TEST_P(DnsFilterIntegrationTest, ExternalLookupTestIPv6) {
   requestResponseWithListenerAddress(*listener_address, query, response);
 
   query_ctx_ = response_parser_->createQueryContext(response, counters_);
-  ASSERT_TRUE(query_ctx_->parse_status_);
+  EXPECT_TRUE(query_ctx_->parse_status_);
 
-  ASSERT_EQ(1, query_ctx_->answers_.size());
-  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  EXPECT_EQ(1, query_ctx_->answers_.size());
+  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, LocalLookupTest) {
@@ -154,10 +154,10 @@ TEST_P(DnsFilterIntegrationTest, LocalLookupTest) {
   requestResponseWithListenerAddress(*listener_address, query, response);
 
   query_ctx_ = response_parser_->createQueryContext(response, counters_);
-  ASSERT_TRUE(query_ctx_->parse_status_);
+  EXPECT_TRUE(query_ctx_->parse_status_);
 
-  ASSERT_EQ(4, query_ctx_->answers_.size());
-  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  EXPECT_EQ(4, query_ctx_->answers_.size());
+  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, ClusterLookupTest) {
@@ -178,10 +178,10 @@ TEST_P(DnsFilterIntegrationTest, ClusterLookupTest) {
   requestResponseWithListenerAddress(*listener_address, query, response);
 
   query_ctx_ = response_parser_->createQueryContext(response, counters_);
-  ASSERT_TRUE(query_ctx_->parse_status_);
+  EXPECT_TRUE(query_ctx_->parse_status_);
 
-  ASSERT_EQ(2, query_ctx_->answers_.size());
-  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  EXPECT_EQ(2, query_ctx_->answers_.size());
+  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 TEST_P(DnsFilterIntegrationTest, ClusterEndpointLookupTest) {
@@ -203,10 +203,10 @@ TEST_P(DnsFilterIntegrationTest, ClusterEndpointLookupTest) {
   requestResponseWithListenerAddress(*listener_address, query, response);
 
   query_ctx_ = response_parser_->createQueryContext(response, counters_);
-  ASSERT_TRUE(query_ctx_->parse_status_);
+  EXPECT_TRUE(query_ctx_->parse_status_);
 
-  ASSERT_EQ(2, query_ctx_->answers_.size());
-  ASSERT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
+  EXPECT_EQ(2, query_ctx_->answers_.size());
+  EXPECT_EQ(DNS_RESPONSE_CODE_NO_ERROR, response_parser_->getQueryResponseCode());
 }
 
 } // namespace

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -3,8 +3,8 @@
 set -e
 
 [[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
-[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=true
-[[ -z "${FUZZ_COVERAGE}" ]] && FUZZ_COVERAGE=false
+[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=false
+[[ -z "${FUZZ_COVERAGE}" ]] && FUZZ_COVERAGE=true
 
 echo "Starting run_envoy_bazel_coverage.sh..."
 echo "    PWD=$(pwd)"

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -3,8 +3,8 @@
 set -e
 
 [[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
-[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=false
-[[ -z "${FUZZ_COVERAGE}" ]] && FUZZ_COVERAGE=true
+[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=true
+[[ -z "${FUZZ_COVERAGE}" ]] && FUZZ_COVERAGE=false
 
 echo "Starting run_envoy_bazel_coverage.sh..."
 echo "    PWD=$(pwd)"


### PR DESCRIPTION
This change adds the code to perform external DNS resolution, and associated tests.

We add stats as well to gauge the operation of the filter.